### PR TITLE
fix: include babel presets in peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ A plugin that allows you to use React as a templating language for Eleventy. Thi
 
 This plugin requires `react`, `react-dom`, `react-helmet`, `@babel/core`, and `babel-loader` as peer dependencies to allow you to have control over which version of these packages you're using.
 
+The `.eleventy.js` snippet below also requires `@babel/preset-react` and `@babel/preset-env` be installed.
+
 ```sh
-npm install eleventy-plugin-react react react-dom react-helmet @babel/core babel-loader
+npm install eleventy-plugin-react react react-dom react-helmet @babel/core babel-loader @babel/preset-react @babel/preset-env
 ```
 
 or
 
 ```sh
-yarn add eleventy-plugin-react react react-dom react-helmet @babel/core babel-loader
+yarn add eleventy-plugin-react react react-dom react-helmet @babel/core babel-loader @babel/preset-react @babel/preset-env
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ A plugin that allows you to use React as a templating language for Eleventy. Thi
 
 ## Installation
 
-This plugin requires `react`, `react-dom`, `react-helmet`, `@babel/core`, and `babel-loader` as peer dependencies to allow you to have control over which version of these packages you're using.
-
-The `.eleventy.js` snippet below also requires `@babel/preset-react` and `@babel/preset-env` be installed.
+This plugin requires `react`, `react-dom`, `react-helmet`, `@babel/core`, `babel-loader`, `@babel/preset-react`, and `@babel/preset-env` as peer dependencies to allow you to have control over which version of these packages you're using.
 
 ```sh
 npm install eleventy-plugin-react react react-dom react-helmet @babel/core babel-loader @babel/preset-react @babel/preset-env

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "peerDependencies": {
     "@11ty/eleventy": ">=0.11.0",
     "@babel/core": ">=7.11.4",
+    "@babel/preset-env": ">=7.11.5",
+    "@babel/preset-react": ">=7.10.4",
     "babel-loader": ">=8.1.0",
     "react": ">=16.13.1",
     "react-dom": ">=16.13.1",


### PR DESCRIPTION
Add Babel presets packages required in `.eleventy.js` to the installation steps.

Fixes #4 