### PR TITLE
Add TSX peerdeps and extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ A plugin that allows you to use React as a templating language for Eleventy. Thi
 
 ## Installation
 
-This plugin requires `react`, `react-dom`, `react-helmet`, `@babel/core`, `babel-loader`, `@babel/preset-react`, and `@babel/preset-env` as peer dependencies to allow you to have control over which version of these packages you're using.
+This plugin requires `react`, `react-dom`, `react-helmet`, `@babel/core`, `babel-loader`, `@babel/preset-react`, `@babel/preset-typescript`, and `@babel/preset-env` as peer dependencies to allow you to have control over which version of these packages you're using.
 
 ```sh
-npm install eleventy-plugin-react react react-dom react-helmet @babel/core babel-loader @babel/preset-react @babel/preset-env
+npm install eleventy-plugin-react react react-dom react-helmet @babel/core babel-loader @babel/preset-react @babel/preset-env @babel/preset-typescript
 ```
 
 or
 
 ```sh
-yarn add eleventy-plugin-react react react-dom react-helmet @babel/core babel-loader @babel/preset-react @babel/preset-env
+yarn add eleventy-plugin-react react react-dom react-helmet @babel/core babel-loader @babel/preset-react @babel/preset-env @babel/preset-typescript
 ```
 
 ## Usage
@@ -34,6 +34,7 @@ module.exports = function (eleventyConfig) {
       return {
         presets: [
           "@babel/preset-react",
+          "@babel/preset-typescript",
           [
             "@babel/preset-env",
             isClientBundle

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -15,7 +15,7 @@ const React = requireFromDir("react", APP_ROOT);
 const ReactDOM = requireFromDir("react-dom/server", APP_ROOT);
 const { Helmet } = requireFromDir("react-helmet", APP_ROOT);
 
-const SUPPORTED_EXTENSIONS = ["js", "jsx"];
+const SUPPORTED_EXTENSIONS = ["js", "jsx", "ts", "tsx"];
 
 const compiledFiles = new Set();
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@babel/core": ">=7.11.4",
     "@babel/preset-env": ">=7.11.5",
     "@babel/preset-react": ">=7.10.4",
+    "@babel/preset-typescript": ">=7.10.4",
     "babel-loader": ">=8.1.0",
     "react": ">=16.13.1",
     "react-dom": ">=16.13.1",


### PR DESCRIPTION
While we consider #8 and #13, I propose we create an initial happy path for Typescript (#12):

* adds .ts and .tsx to supported extensions
* adds @babel/preset-typescript to peer deps
* fixes #12 
